### PR TITLE
feat: add inline code, ordered lists, horizontal rules, bold+italic, strikethrough

### DIFF
--- a/substack/post.py
+++ b/substack/post.py
@@ -2,15 +2,35 @@
 
 Post Utilities
 
+Post Utilities
+
 """
 
 import json
 import re
 from typing import Dict, List
 
-__all__ = ["Post", "parse_inline"]
+__all__ = ["Post", "parse_inline", "tokens_to_text_nodes"]
 
 from substack.exceptions import SectionNotExistsException
+
+
+def tokens_to_text_nodes(tokens: List[Dict]) -> List[Dict]:
+    """Convert parse_inline() tokens to ProseMirror text nodes.
+
+    parse_inline() returns {"content": "text", "marks": [...]}.
+    ProseMirror expects {"type": "text", "text": "text", "marks": [...]}.
+    """
+    nodes = []
+    for token in tokens:
+        if not token or not token.get("content"):
+            continue
+        node = {"type": "text", "text": token["content"]}
+        marks = token.get("marks")
+        if marks:
+            node["marks"] = marks
+        nodes.append(node)
+    return nodes
 
 
 def parse_inline(text: str) -> List[Dict]:
@@ -19,8 +39,11 @@ def parse_inline(text: str) -> List[Dict]:
     for use in the post content.
 
     Supported formatting:
+      - `code`: Text wrapped in backticks.
       - **Bold**: Text wrapped in double asterisks.
       - *Italic*: Text wrapped in single asterisks.
+      - ***Bold+Italic***: Text wrapped in triple asterisks.
+      - ~~Strikethrough~~: Text wrapped in double tildes.
       - [Links]: Text wrapped in square brackets followed by URL in parentheses.
 
     Args:
@@ -37,32 +60,49 @@ def parse_inline(text: str) -> List[Dict]:
         return []
 
     tokens = []
-    # Process text character by character to handle nested formatting
-    # We'll use regex to find all markdown patterns, then process them in order
 
-    # Find all markdown patterns: links, bold, italic
-    # Pattern order: links first (to avoid conflicts), then bold, then italic
+    # Pattern order matters: code > links > bold+italic > bold > italic > strikethrough
+    code_pattern = r'`([^`]+)`'
     link_pattern = r'\[([^\]]+)\]\(([^)]+)\)'
+    bold_italic_pattern = r'\*\*\*([^*]+)\*\*\*'
     bold_pattern = r'\*\*([^*]+)\*\*'
     italic_pattern = r'(?<!\*)\*([^*]+)\*(?!\*)'  # Not preceded or followed by *
+    strikethrough_pattern = r'~~([^~]+)~~'
 
     # Find all matches with their positions
     matches = []
+
+    # 1. Inline code FIRST -- content inside backticks must not be parsed for other formatting
+    for match in re.finditer(code_pattern, text):
+        matches.append((match.start(), match.end(), "code", match.group(1), None))
+
+    # 2. Links
     for match in re.finditer(link_pattern, text):
         # Skip if it's an image link (starts with ![)
         # But do NOT skip normal links at position 0.
         if match.start() == 0 or text[match.start()-1:match.start()+1] != "![":
-            matches.append((match.start(), match.end(), "link", match.group(1), match.group(2)))
+            if not any(start <= match.start() < end for start, end, _, _, _ in matches):
+                matches.append((match.start(), match.end(), "link", match.group(1), match.group(2)))
 
+    # 3. Bold+italic combo
+    for match in re.finditer(bold_italic_pattern, text):
+        if not any(start <= match.start() < end for start, end, _, _, _ in matches):
+            matches.append((match.start(), match.end(), "bold_italic", match.group(1), None))
+
+    # 4. Bold
     for match in re.finditer(bold_pattern, text):
-        # Check if this range is already covered by a link
         if not any(start <= match.start() < end for start, end, _, _, _ in matches):
             matches.append((match.start(), match.end(), "bold", match.group(1), None))
 
+    # 5. Italic
     for match in re.finditer(italic_pattern, text):
-        # Check if this range is already covered by a link or bold
         if not any(start <= match.start() < end for start, end, _, _, _ in matches):
             matches.append((match.start(), match.end(), "italic", match.group(1), None))
+
+    # 6. Strikethrough
+    for match in re.finditer(strikethrough_pattern, text):
+        if not any(start <= match.start() < end for start, end, _, _, _ in matches):
+            matches.append((match.start(), match.end(), "strikethrough", match.group(1), None))
 
     # Sort matches by position
     matches.sort(key=lambda x: x[0])
@@ -75,10 +115,20 @@ def parse_inline(text: str) -> List[Dict]:
             tokens.append({"content": text[last_pos:start]})
 
         # Add the formatted content
-        if match_type == "link":
+        if match_type == "code":
+            tokens.append({
+                "content": content,
+                "marks": [{"type": "code"}]
+            })
+        elif match_type == "link":
             tokens.append({
                 "content": content,
                 "marks": [{"type": "link", "attrs": {"href": url}}]
+            })
+        elif match_type == "bold_italic":
+            tokens.append({
+                "content": content,
+                "marks": [{"type": "strong"}, {"type": "em"}]
             })
         elif match_type == "bold":
             tokens.append({
@@ -89,6 +139,11 @@ def parse_inline(text: str) -> List[Dict]:
             tokens.append({
                 "content": content,
                 "marks": [{"type": "em"}]
+            })
+        elif match_type == "strikethrough":
+            tokens.append({
+                "content": content,
+                "marks": [{"type": "strikethrough"}]
             })
 
         last_pos = end
@@ -503,7 +558,9 @@ class Post:
           - Blockquotes: Lines starting with '>' (consecutive lines grouped)
           - Paragraphs: Regular text blocks
           - Bullet lists: Lines starting with '*' or '-'
-          - Inline formatting: **bold** and *italic* within paragraphs
+          - Ordered lists: Lines starting with '1.', '2.', etc.
+          - Horizontal rules: Lines with ---, ***, or ___
+          - Inline formatting: **bold**, *italic*, ***bold+italic***, `code`, ~~strikethrough~~
 
         Args:
             markdown_content: Markdown string to parse and add to the post.
@@ -593,6 +650,11 @@ class Post:
                 if not text_content:
                     continue
 
+                # Check for horizontal rule: ---, ***, ___
+                if re.match(r'^(\*{3,}|-{3,}|_{3,})\s*$', text_content):
+                    self.horizontal_rule()
+                    continue
+
                 # Process headings (lines starting with '#' characters)
                 if text_content.startswith("#"):
                     level = len(text_content) - len(text_content.lstrip("#"))
@@ -648,14 +710,15 @@ class Post:
 
                             self.add({"type": "captionedImage", "src": image_url})
 
-                # Process paragraphs, bullet lists, or blockquotes
+                # Process paragraphs, bullet lists, ordered lists, or blockquotes
                 else:
                     if "\n" in text_content:
-                        # Process each line, grouping consecutive bullets
-                        # into a single bullet_list node and consecutive
-                        # blockquote lines into a single blockquote node.
+                        # Process each line, grouping consecutive bullets/ordered items
+                        # into list nodes and consecutive blockquote lines into a
+                        # single blockquote node.
                         pending_bullets: List[List[Dict]] = []
                         pending_quotes: List[str] = []
+                        pending_ordered: List[List[Dict]] = []
 
                         def flush_bullets():
                             if not pending_bullets:
@@ -677,10 +740,7 @@ class Post:
                             paragraphs: List[Dict] = []
                             for quote_line in pending_quotes:
                                 tokens = parse_inline(quote_line)
-                                text_nodes = [
-                                    {"type": "text", "text": t["content"]}
-                                    for t in tokens if t
-                                ]
+                                text_nodes = tokens_to_text_nodes(tokens)
                                 if text_nodes:
                                     paragraphs.append({"type": "paragraph", "content": text_nodes})
                             node: Dict = {"type": "blockquote"}
@@ -689,18 +749,46 @@ class Post:
                             self.draft_body["content"].append(node)
                             pending_quotes.clear()
 
+                        def flush_ordered():
+                            if not pending_ordered:
+                                return
+                            list_items = []
+                            for item_nodes in pending_ordered:
+                                list_items.append({
+                                    "type": "list_item",
+                                    "content": [{"type": "paragraph", "content": item_nodes}],
+                                })
+                            self.draft_body["content"].append(
+                                {"type": "ordered_list", "content": list_items}
+                            )
+                            pending_ordered.clear()
+
                         for line in text_content.split("\n"):
                             line = line.strip()
                             if not line:
                                 flush_bullets()
+                                flush_ordered()
                                 flush_quotes()
                                 continue
 
                             # Check for blockquote marker
                             if line.startswith("> ") or line == ">":
                                 flush_bullets()
+                                flush_ordered()
                                 quote_text = line[2:] if line.startswith("> ") else ""
                                 pending_quotes.append(quote_text)
+                                continue
+
+                            # Check for ordered list marker
+                            ordered_match = re.match(r'^(\d+)\.\s+(.*)', line)
+                            if ordered_match:
+                                flush_bullets()
+                                flush_quotes()
+                                item_text = ordered_match.group(2).strip()
+                                tokens = parse_inline(item_text)
+                                text_nodes = tokens_to_text_nodes(tokens)
+                                if text_nodes:
+                                    pending_ordered.append(text_nodes)
                                 continue
 
                             # Check for bullet marker
@@ -713,33 +801,49 @@ class Post:
                                 bullet_text = line[1:].strip()
 
                             if bullet_text is not None:
+                                flush_ordered()
                                 flush_quotes()
                                 tokens = parse_inline(bullet_text)
-                                if tokens:
-                                    pending_bullets.append(tokens)
+                                text_nodes = tokens_to_text_nodes(tokens)
+                                if text_nodes:
+                                    pending_bullets.append(text_nodes)
                             else:
                                 flush_bullets()
+                                flush_ordered()
                                 flush_quotes()
                                 tokens = parse_inline(line)
                                 self.add({"type": "paragraph", "content": tokens})
 
                         flush_bullets()
+                        flush_ordered()
                         flush_quotes()
                     else:
-                        # Single line — could be a blockquote or paragraph
+                        # Single line — could be a blockquote, ordered list, or paragraph
                         if text_content.startswith("> ") or text_content == ">":
                             quote_text = text_content[2:] if text_content.startswith("> ") else ""
                             tokens = parse_inline(quote_text)
-                            text_nodes = [
-                                {"type": "text", "text": t["content"]}
-                                for t in tokens if t
-                            ]
+                            text_nodes = tokens_to_text_nodes(tokens)
                             para = {"type": "paragraph", "content": text_nodes} if text_nodes else {"type": "paragraph"}
                             self.draft_body["content"] = self.draft_body.get("content", []) + [
                                 {"type": "blockquote", "content": [para]}
                             ]
                         else:
-                            tokens = parse_inline(text_content)
-                            self.add({"type": "paragraph", "content": tokens})
+                            # Check for single-line ordered list
+                            ordered_match = re.match(r'^(\d+)\.\s+(.*)', text_content)
+                            if ordered_match:
+                                item_text = ordered_match.group(2).strip()
+                                tokens = parse_inline(item_text)
+                                text_nodes = tokens_to_text_nodes(tokens)
+                                if text_nodes:
+                                    list_item = {
+                                        "type": "list_item",
+                                        "content": [{"type": "paragraph", "content": text_nodes}],
+                                    }
+                                    self.draft_body["content"].append(
+                                        {"type": "ordered_list", "content": [list_item]}
+                                    )
+                            else:
+                                tokens = parse_inline(text_content)
+                                self.add({"type": "paragraph", "content": tokens})
 
         return self

--- a/substack/post.py
+++ b/substack/post.py
@@ -2,8 +2,6 @@
 
 Post Utilities
 
-Post Utilities
-
 """
 
 import json
@@ -72,11 +70,11 @@ def parse_inline(text: str) -> List[Dict]:
     # Find all matches with their positions
     matches = []
 
-    # 1. Inline code FIRST -- content inside backticks must not be parsed for other formatting
+    # Inline code FIRST -- content inside backticks must not be parsed for other formatting
     for match in re.finditer(code_pattern, text):
         matches.append((match.start(), match.end(), "code", match.group(1), None))
 
-    # 2. Links
+    # Links
     for match in re.finditer(link_pattern, text):
         # Skip if it's an image link (starts with ![)
         # But do NOT skip normal links at position 0.
@@ -84,22 +82,22 @@ def parse_inline(text: str) -> List[Dict]:
             if not any(start <= match.start() < end for start, end, _, _, _ in matches):
                 matches.append((match.start(), match.end(), "link", match.group(1), match.group(2)))
 
-    # 3. Bold+italic combo
+    # Bold+italic combo
     for match in re.finditer(bold_italic_pattern, text):
         if not any(start <= match.start() < end for start, end, _, _, _ in matches):
             matches.append((match.start(), match.end(), "bold_italic", match.group(1), None))
 
-    # 4. Bold
+    # Bold
     for match in re.finditer(bold_pattern, text):
         if not any(start <= match.start() < end for start, end, _, _, _ in matches):
             matches.append((match.start(), match.end(), "bold", match.group(1), None))
 
-    # 5. Italic
+    # Italic
     for match in re.finditer(italic_pattern, text):
         if not any(start <= match.start() < end for start, end, _, _, _ in matches):
             matches.append((match.start(), match.end(), "italic", match.group(1), None))
 
-    # 6. Strikethrough
+    # Strikethrough
     for match in re.finditer(strikethrough_pattern, text):
         if not any(start <= match.start() < end for start, end, _, _, _ in matches):
             matches.append((match.start(), match.end(), "strikethrough", match.group(1), None))
@@ -818,7 +816,7 @@ class Post:
                         flush_ordered()
                         flush_quotes()
                     else:
-                        # Single line — could be a blockquote, ordered list, or paragraph
+                        # Single line — blockquote, ordered list, or paragraph
                         if text_content.startswith("> ") or text_content == ">":
                             quote_text = text_content[2:] if text_content.startswith("> ") else ""
                             tokens = parse_inline(quote_text)
@@ -827,23 +825,23 @@ class Post:
                             self.draft_body["content"] = self.draft_body.get("content", []) + [
                                 {"type": "blockquote", "content": [para]}
                             ]
-                        else:
-                            # Check for single-line ordered list
+
+                        elif re.match(r'^(\d+)\.\s+(.*)', text_content):
                             ordered_match = re.match(r'^(\d+)\.\s+(.*)', text_content)
-                            if ordered_match:
-                                item_text = ordered_match.group(2).strip()
-                                tokens = parse_inline(item_text)
-                                text_nodes = tokens_to_text_nodes(tokens)
-                                if text_nodes:
-                                    list_item = {
-                                        "type": "list_item",
-                                        "content": [{"type": "paragraph", "content": text_nodes}],
-                                    }
-                                    self.draft_body["content"].append(
-                                        {"type": "ordered_list", "content": [list_item]}
-                                    )
-                            else:
-                                tokens = parse_inline(text_content)
-                                self.add({"type": "paragraph", "content": tokens})
+                            item_text = ordered_match.group(2).strip()
+                            tokens = parse_inline(item_text)
+                            text_nodes = tokens_to_text_nodes(tokens)
+                            if text_nodes:
+                                list_item = {
+                                    "type": "list_item",
+                                    "content": [{"type": "paragraph", "content": text_nodes}],
+                                }
+                                self.draft_body["content"].append(
+                                    {"type": "ordered_list", "content": [list_item]}
+                                )
+
+                        else:
+                            tokens = parse_inline(text_content)
+                            self.add({"type": "paragraph", "content": tokens})
 
         return self

--- a/tests/substack/test_post_extended.py
+++ b/tests/substack/test_post_extended.py
@@ -1,0 +1,306 @@
+"""Tests for extended post.py -- inline code, ordered lists, horizontal rules, bold+italic, strikethrough."""
+
+import json
+
+import pytest
+from substack.post import Post, parse_inline
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_post():
+    """Create a fresh Post instance for testing."""
+    return Post(title="Test", subtitle="Sub", user_id=1)
+
+
+def body_content(post):
+    """Return the content list from the post's draft body."""
+    return post.draft_body["content"]
+
+
+# ---------------------------------------------------------------------------
+# TestParseInlineCode
+# ---------------------------------------------------------------------------
+
+class TestParseInlineCode:
+    def test_inline_code_basic(self):
+        tokens = parse_inline("`code`")
+        assert len(tokens) == 1
+        assert tokens[0]["content"] == "code"
+        assert tokens[0]["marks"] == [{"type": "code"}]
+
+    def test_inline_code_in_sentence(self):
+        tokens = parse_inline("Use `foo()` here")
+        assert len(tokens) == 3
+        assert tokens[0] == {"content": "Use "}
+        assert tokens[1] == {"content": "foo()", "marks": [{"type": "code"}]}
+        assert tokens[2] == {"content": " here"}
+
+    def test_inline_code_preserves_special_chars(self):
+        tokens = parse_inline("`**not bold**`")
+        assert len(tokens) == 1
+        assert tokens[0]["content"] == "**not bold**"
+        assert tokens[0]["marks"] == [{"type": "code"}]
+
+    def test_inline_code_multiple(self):
+        tokens = parse_inline("`a` and `b`")
+        assert len(tokens) == 3
+        assert tokens[0] == {"content": "a", "marks": [{"type": "code"}]}
+        assert tokens[1] == {"content": " and "}
+        assert tokens[2] == {"content": "b", "marks": [{"type": "code"}]}
+
+    def test_inline_code_empty_backticks(self):
+        tokens = parse_inline("``")
+        # Empty backticks should not match the code pattern
+        assert len(tokens) == 1
+        assert tokens[0] == {"content": "``"}
+
+
+# ---------------------------------------------------------------------------
+# TestParseInlineBoldItalic
+# ---------------------------------------------------------------------------
+
+class TestParseInlineBoldItalic:
+    def test_bold_italic_combo(self):
+        tokens = parse_inline("***text***")
+        assert len(tokens) == 1
+        assert tokens[0]["content"] == "text"
+        assert {"type": "strong"} in tokens[0]["marks"]
+        assert {"type": "em"} in tokens[0]["marks"]
+
+    def test_bold_italic_in_sentence(self):
+        tokens = parse_inline("This is ***important*** stuff")
+        assert len(tokens) == 3
+        assert tokens[0] == {"content": "This is "}
+        assert tokens[1]["content"] == "important"
+        assert {"type": "strong"} in tokens[1]["marks"]
+        assert {"type": "em"} in tokens[1]["marks"]
+        assert tokens[2] == {"content": " stuff"}
+
+    def test_bold_italic_does_not_break_bold(self):
+        tokens = parse_inline("**bold** and ***both***")
+        assert len(tokens) == 3
+        assert tokens[0]["content"] == "bold"
+        assert tokens[0]["marks"] == [{"type": "strong"}]
+        assert tokens[2]["content"] == "both"
+        assert {"type": "strong"} in tokens[2]["marks"]
+        assert {"type": "em"} in tokens[2]["marks"]
+
+    def test_bold_italic_does_not_break_italic(self):
+        tokens = parse_inline("*italic* and ***both***")
+        assert len(tokens) == 3
+        assert tokens[0]["content"] == "italic"
+        assert tokens[0]["marks"] == [{"type": "em"}]
+        assert tokens[2]["content"] == "both"
+        assert {"type": "strong"} in tokens[2]["marks"]
+        assert {"type": "em"} in tokens[2]["marks"]
+
+
+# ---------------------------------------------------------------------------
+# TestParseInlineStrikethrough
+# ---------------------------------------------------------------------------
+
+class TestParseInlineStrikethrough:
+    def test_strikethrough_basic(self):
+        tokens = parse_inline("~~struck~~")
+        assert len(tokens) == 1
+        assert tokens[0]["content"] == "struck"
+        assert tokens[0]["marks"] == [{"type": "strikethrough"}]
+
+    def test_strikethrough_in_sentence(self):
+        tokens = parse_inline("This is ~~wrong~~ right")
+        assert len(tokens) == 3
+        assert tokens[0] == {"content": "This is "}
+        assert tokens[1] == {"content": "wrong", "marks": [{"type": "strikethrough"}]}
+        assert tokens[2] == {"content": " right"}
+
+    def test_strikethrough_with_other_marks(self):
+        tokens = parse_inline("**bold** and ~~struck~~")
+        assert len(tokens) == 3
+        assert tokens[0]["marks"] == [{"type": "strong"}]
+        assert tokens[2]["marks"] == [{"type": "strikethrough"}]
+
+
+# ---------------------------------------------------------------------------
+# TestOrderedListFromMarkdown
+# ---------------------------------------------------------------------------
+
+class TestOrderedListFromMarkdown:
+    def test_basic_ordered_list(self):
+        post = make_post()
+        post.from_markdown("1. a\n2. b\n3. c")
+        content = body_content(post)
+        assert len(content) == 1
+        ol = content[0]
+        assert ol["type"] == "ordered_list"
+        assert len(ol["content"]) == 3
+        for item in ol["content"]:
+            assert item["type"] == "list_item"
+
+    def test_ordered_list_with_inline_formatting(self):
+        post = make_post()
+        post.from_markdown("1. **bold item**\n2. normal")
+        content = body_content(post)
+        ol = content[0]
+        first_item_tokens = ol["content"][0]["content"][0]["content"]
+        assert any(
+            t.get("marks") == [{"type": "strong"}]
+            for t in first_item_tokens
+        )
+
+    def test_ordered_list_single_item(self):
+        post = make_post()
+        post.from_markdown("1. only")
+        content = body_content(post)
+        assert len(content) == 1
+        assert content[0]["type"] == "ordered_list"
+        assert len(content[0]["content"]) == 1
+
+    def test_mixed_list_types(self):
+        post = make_post()
+        post.from_markdown("- bullet a\n- bullet b\n\n1. ordered a\n2. ordered b")
+        content = body_content(post)
+        types = [node["type"] for node in content]
+        assert "bullet_list" in types
+        assert "ordered_list" in types
+
+    def test_ordered_list_non_sequential_numbers(self):
+        post = make_post()
+        post.from_markdown("1. a\n5. b\n3. c")
+        content = body_content(post)
+        ol = content[0]
+        assert ol["type"] == "ordered_list"
+        assert len(ol["content"]) == 3
+
+    def test_ordered_list_with_links(self):
+        post = make_post()
+        post.from_markdown("1. [link](https://example.com)\n2. plain")
+        content = body_content(post)
+        ol = content[0]
+        first_item_tokens = ol["content"][0]["content"][0]["content"]
+        assert any(
+            any(m.get("type") == "link" for m in t.get("marks", []))
+            for t in first_item_tokens
+        )
+
+    def test_single_line_ordered_item(self):
+        """A single ordered list item as its own block (no newlines in block)."""
+        post = make_post()
+        # Surround with blank lines so it's its own block
+        post.from_markdown("\n1. item\n")
+        content = body_content(post)
+        assert any(node["type"] == "ordered_list" for node in content)
+
+
+# ---------------------------------------------------------------------------
+# TestHorizontalRuleFromMarkdown
+# ---------------------------------------------------------------------------
+
+class TestHorizontalRuleFromMarkdown:
+    def test_horizontal_rule_dashes(self):
+        post = make_post()
+        post.from_markdown("text\n\n---\n\nmore text")
+        content = body_content(post)
+        types = [node["type"] for node in content]
+        assert "horizontal_rule" in types
+
+    def test_horizontal_rule_asterisks(self):
+        post = make_post()
+        post.from_markdown("text\n\n***\n\nmore text")
+        content = body_content(post)
+        types = [node["type"] for node in content]
+        assert "horizontal_rule" in types
+
+    def test_horizontal_rule_underscores(self):
+        post = make_post()
+        post.from_markdown("text\n\n___\n\nmore text")
+        content = body_content(post)
+        types = [node["type"] for node in content]
+        assert "horizontal_rule" in types
+
+    def test_horizontal_rule_extended(self):
+        post = make_post()
+        post.from_markdown("text\n\n-----\n\nmore text")
+        content = body_content(post)
+        types = [node["type"] for node in content]
+        assert "horizontal_rule" in types
+
+    def test_horizontal_rule_between_paragraphs(self):
+        post = make_post()
+        post.from_markdown("above\n\n---\n\nbelow")
+        content = body_content(post)
+        assert len(content) == 3
+        assert content[0]["type"] == "paragraph"
+        assert content[1]["type"] == "horizontal_rule"
+        assert content[2]["type"] == "paragraph"
+
+    def test_horizontal_rule_not_in_code_block(self):
+        post = make_post()
+        post.from_markdown("```\n---\n```")
+        content = body_content(post)
+        types = [node["type"] for node in content]
+        assert "horizontal_rule" not in types
+        assert "codeBlock" in types
+
+
+# ---------------------------------------------------------------------------
+# TestExistingFeaturesUnchanged
+# ---------------------------------------------------------------------------
+
+class TestExistingFeaturesUnchanged:
+    def test_bold(self):
+        tokens = parse_inline("**bold**")
+        assert len(tokens) == 1
+        assert tokens[0]["content"] == "bold"
+        assert tokens[0]["marks"] == [{"type": "strong"}]
+
+    def test_italic(self):
+        tokens = parse_inline("*italic*")
+        assert len(tokens) == 1
+        assert tokens[0]["content"] == "italic"
+        assert tokens[0]["marks"] == [{"type": "em"}]
+
+    def test_links(self):
+        tokens = parse_inline("[text](https://example.com)")
+        assert len(tokens) == 1
+        assert tokens[0]["content"] == "text"
+        assert tokens[0]["marks"] == [{"type": "link", "attrs": {"href": "https://example.com"}}]
+
+    def test_bullet_list(self):
+        post = make_post()
+        post.from_markdown("- a\n- b\n- c")
+        content = body_content(post)
+        assert len(content) == 1
+        assert content[0]["type"] == "bullet_list"
+        assert len(content[0]["content"]) == 3
+
+    def test_code_block(self):
+        post = make_post()
+        post.from_markdown("```python\nprint('hello')\n```")
+        content = body_content(post)
+        assert len(content) == 1
+        assert content[0]["type"] == "codeBlock"
+
+    def test_blockquote(self):
+        post = make_post()
+        post.from_markdown("> quote text")
+        content = body_content(post)
+        assert len(content) == 1
+        assert content[0]["type"] == "blockquote"
+
+    def test_heading(self):
+        post = make_post()
+        post.from_markdown("## Heading Two")
+        content = body_content(post)
+        assert len(content) == 1
+        assert content[0]["type"] == "heading"
+        assert content[0]["attrs"]["level"] == 2
+
+    def test_image(self):
+        post = make_post()
+        post.from_markdown("![alt](https://example.com/img.png)")
+        content = body_content(post)
+        assert len(content) == 1
+        assert content[0]["type"] == "captionedImage"


### PR DESCRIPTION
This was raised by an LLM, but I (a human) have verified this works on my substack

## Summary

Extends `parse_inline()` and `from_markdown()` with missing markdown features, plus fixes a bug where list items and blockquotes produced invalid ProseMirror JSON.

## Changes

### New inline formatting in `parse_inline()`
- **Inline code** (`` `code` ``) → `{"type": "code"}` mark
- **Bold+italic combo** (`***text***`) → `[{"type": "strong"}, {"type": "em"}]` marks
- **Strikethrough** (`~~text~~`) → `{"type": "strikethrough"}` mark
- Pattern ordering: code > links > bold+italic > bold > italic > strikethrough

### New block elements in `from_markdown()`
- **Ordered lists** (`1. item`) → `{"type": "ordered_list"}` node, mirroring existing bullet list pattern
- **Horizontal rules** (`---`, `***`, `___`) → calls existing `horizontal_rule()` method

### Bug fix: `tokens_to_text_nodes()`
List items and blockquotes were using raw `parse_inline()` tokens (`{"content": "text"}`) instead of valid ProseMirror text nodes (`{"type": "text", "text": "text"}`). This caused Substack's editor to render empty bodies. Marks were also being dropped in blockquotes.

## Testing

- 33 new unit tests in `tests/substack/test_post_extended.py`
- All 16 existing `test_post.py` tests pass unchanged
- All features E2E verified against live Substack API — drafts render correctly