### PR TITLE
Fix subscriber count response handling

### DIFF
--- a/substack/api.py
+++ b/substack/api.py
@@ -346,7 +346,10 @@ class Api:
             f"{self.publication_url}/publication_launch_checklist"
         )
 
-        return Api._handle_response(response=response)["subscriberCount"]
+        data = Api._handle_response(response=response)
+        if "subscriberCount" in data:
+            return data["subscriberCount"]
+        return len(data["subscribers"])
 
     def get_published_posts(
         self, offset=0, limit=25, order_by="post_date", order_direction="desc"

--- a/tests/substack/test_api.py
+++ b/tests/substack/test_api.py
@@ -40,6 +40,26 @@ class ApiTest(unittest.TestCase):
             with patch("requests.Session.post", return_value=response):
                 Api(email="", password="")
 
+    def test_get_publication_subscriber_count_from_legacy_response(self):
+        api = Api.__new__(Api)
+        api.publication_url = "https://writer.substack.com/api/v1"
+        api._session = Mock()
+        response = Mock(status_code=200)
+        response.json.return_value = {"subscriberCount": 123}
+        api._session.get.return_value = response
+
+        self.assertEqual(api.get_publication_subscriber_count(), 123)
+
+    def test_get_publication_subscriber_count_from_subscribers(self):
+        api = Api.__new__(Api)
+        api.publication_url = "https://writer.substack.com/api/v1"
+        api._session = Mock()
+        response = Mock(status_code=200)
+        response.json.return_value = {"subscribers": [{"id": 1}, {"id": 2}]}
+        api._session.get.return_value = response
+
+        self.assertEqual(api.get_publication_subscriber_count(), 2)
+
     @_e2e
     def test_get_posts(self):
         api = _api_from_env()


### PR DESCRIPTION
## Summary

- support Substack's current `subscribers` list response
- preserve compatibility with the legacy `subscriberCount` response
- add regression tests for both response shapes

## Root cause

The publication launch checklist endpoint no longer returns a top-level `subscriberCount` for this account. It now returns subscriber records in a `subscribers` list, causing `substack status` to raise `KeyError`.

## Impact

`substack status` reports the subscriber count with both the current and legacy API response formats.

## Validation

- `python -m pytest tests/substack/test_api.py tests/substack/test_cli_operations.py -q`: 23 passed, 5 skipped
- live `substack status`: completed successfully
- commit hooks: Check Yaml, Fix End of Files, Trim Trailing Whitespace, black, and isort passed

The full suite remains blocked by the unrelated missing `mdit_py_plugins.subscript` module in the local environment.
